### PR TITLE
keep only typescript specific rules

### DIFF
--- a/configs/basic.js
+++ b/configs/basic.js
@@ -8,6 +8,7 @@ module.exports = {
     'interface-name': true,
     'jsdoc-format': true,
     'no-angle-bracket-type-assertion': true,
+    'no-parameter-properties': false,
     typedef: [
       true,
       'call-signature',

--- a/configs/basic.js
+++ b/configs/basic.js
@@ -5,6 +5,7 @@ module.exports = {
       'array'
     ],
     'await-promise': true,
+    'ban-ts-ignore': false,
     'interface-name': true,
     'jsdoc-format': true,
     'no-angle-bracket-type-assertion': true,

--- a/configs/basic.js
+++ b/configs/basic.js
@@ -1,156 +1,13 @@
 module.exports = {
-  extends: [
-    'tslint:all'
-  ],
-
   rules: {
-    align: [
-      true,
-      'parameters',
-      'statements'
-    ],
     'array-type': [
       true,
       'array'
     ],
-    'arrow-return-shorthand': [
-      true,
-      'multiline'
-    ],
     'await-promise': true,
-    ban: false,
-    'ban-ts-ignore': false,
-    'ban-types': false,
-    'binary-expression-operand-order': false,
-    'class-name': true,
-    'comment-format': [
-      true,
-      'check-space'
-    ],
-    'completed-docs': false,
-    curly: true,
-    'cyclomaticComplexity': [
-      true,
-      20
-    ],
-    eofline: true,
-    'file-name-casing': [
-      true,
-      'kebab-case'
-    ],
-    forin: true,
-    'import-spacing': true,
-    'increment-decrement': false,
-    indent: [
-      true,
-      'spaces'
-    ],
     'interface-name': true,
     'jsdoc-format': true,
-    'label-position': true,
-    'match-default-export-name': true,
-    'max-classes-per-file': [
-      true,
-      2
-    ],
-    'max-line-length': [
-      true,
-      200
-    ],
-    'member-access': false,
-    'member-ordering': [
-      true,
-      'static-before-instance',
-      'variables-before-functions'
-    ],
-    'newline-before-return': false,
-    'newline-per-chained-call': false,
     'no-angle-bracket-type-assertion': true,
-    'no-any': false,
-    'no-arg': true,
-    'no-bitwise': true,
-    'no-boolean-literal-compare': true,
-    'no-conditional-assignment': true,
-    'no-consecutive-blank-lines': false,
-    'no-console': false,
-    'no-construct': true,
-    'no-debugger': true,
-    'no-default-export': false,
-    'no-dynamic-delete': false,
-    'no-duplicate-super': true,
-    'no-duplicate-variable': true,
-    'no-empty': true,
-    'no-eval': true,
-    'no-floating-promises': true,
-    'no-inferrable-types': false,
-    'no-internal-module': true,
-    'no-import-side-effect': false, // true, // FIXME
-    'no-magic-numbers': false,
-    'no-misused-new': true,
-    'no-non-null-assertion': true,
-    'no-null-keyword': false,
-    'no-parameter-properties': false,
-    'no-parameter-reassignment': false,
-    'no-require-imports': true,
-    'no-shadowed-variable': true,
-    'no-string-literal': true,
-    'no-submodule-imports': false,
-    'no-switch-case-fall-through': true,
-    'no-trailing-whitespace': true,
-    'no-unbound-method': true,
-    'no-unnecessary-initializer': true,
-    'no-unnecessary-qualifier': true,
-    'no-unsafe-any': true,
-    'no-unused-expression': true,
-    'no-use-before-declare': true,
-    'no-var-keyword': true,
-    'no-var-requires': true,
-    'no-unnecessary-class': false,
-    'object-literal-key-quotes': [
-      true,
-      'as-needed'
-    ],
-    'object-literal-sort-keys': false,
-    'one-line': [
-      true,
-      'check-open-brace',
-      'check-catch',
-      'check-else',
-      'check-finally',
-      'check-whitespace'
-    ],
-    'only-arrow-functions': false,
-    'prefer-for-of': false,
-    'prefer-function-over-method': false, // true, // FIXME
-    'prefer-method-signature': true,
-    quotemark: [
-      true,
-      'single',
-      'avoid-escape'
-    ],
-    radix: true,
-    'semicolon': [
-      true,
-      'always'
-    ],
-    'space-before-function-paren': [
-      true,
-      'never'
-    ],
-    'strict-boolean-expressions': false,
-    'strict-type-predicates': true,
-    'switch-default': true,
-    'trailing-comma': [
-      true,
-      {
-        'multiline': 'never',
-        'singleline': 'never'
-      }
-    ],
-    'triple-equals': [
-      true,
-      'allow-null-check'
-    ],
     typedef: [
       true,
       'call-signature',
@@ -173,24 +30,7 @@ module.exports = {
         'variable-declaration': 'space'
       }
     ],
-    'typeof-compare': true,
     'unified-signatures': true,
-    'variable-name': [
-      true,
-      // 'check-format'
-      'ban-keywords'
-    ],
-    whitespace: [
-      true,
-      'check-branch',
-      'check-decl',
-      'check-operator',
-      'check-preblock',
-      'check-separator',
-      'check-type'
-    ],
-
-
     'promise-function-async': true,
     'no-null-undefined-union': true,
     'type-literal-delimiter': true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "tslint-config-firecloud",
   "description": "The TSLint config used within Tobii Cloud Services.",
-  "version": "0.1.0",
+  "version": "0.2.0-eslint.0",
   "license": "Unlicense",
   "files": [
     "/BUILD",


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->

goal is to remove any other rule that is generic to javascript. all those rules can or will be handled by eslint

only rules related to types or formatting of types should be kept

dear reviewers, could you just do a cursory check for rules that you bump into that are typescript-specific, and see that they are still there?